### PR TITLE
Lookup image repository by namespace/name instead of dockerImageRepository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN yum update -y && \
     yum install -y epel-release && \
     yum install -y python-pip \
                    python-devel \
-                   python-backports-lzma \
                    python-boto \
                    python-redis \
                    python-blinker \
@@ -25,6 +24,7 @@ RUN yum update -y && \
                    libev \
                    python-greenlet \
                    unzip \
+                   xz-devel \
                    gcc && \
     curl -L -O https://github.com/openshift/docker-registry/archive/master.zip && \
     unzip master.zip && \

--- a/openshift/tag_created.py
+++ b/openshift/tag_created.py
@@ -50,7 +50,7 @@ def tag_created(sender, namespace, repository, tag, value):
 
 def _post_repository_binding(namespace, repository, tag, image_id, image):
     url = '{0}/imageRepositoryMappings'.format(openshift_url)
-    params = {"sync": "true"}
+    params = {"sync": "true", "namespace": namespace}
     headers = {}
     # headers = {'Authorization': self.authorization}
 
@@ -59,10 +59,14 @@ def _post_repository_binding(namespace, repository, tag, image_id, image):
     body = {
         "kind": "ImageRepositoryMapping",
         "apiVersion": "v1beta1",
+        "metadata": {
+            "name": repository,
+            "namespace": namespace,
+        },
         "dockerImageRepository": name,
         "image": {
             "metadata": {
-              "name": image_id,
+                "name": image_id,
             },
             "dockerImageReference": ref,
             "dockerImageMetadata": {


### PR DESCRIPTION
This is backwards compatible with older API servers (unlike the original version of the pull).
https://github.com/openshift/origin/pull/635

@ncdc