### PR TITLE
Add file to build environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN yum update -y && \
                    python-greenlet \
                    unzip \
                    xz-devel \
+                   file \
                    gcc && \
     curl -L -O https://github.com/openshift/docker-registry/archive/master.zip && \
     unzip master.zip && \


### PR DESCRIPTION
The build logs have a lot of this error which should be resolved by installing
file. I'm not sure there are any problems created by this, just something I noticed while building the image.

```
/tmp/pip-build-uhIycV/gevent/c-ares/configure: line 8684: /usr/bin/file: No
such file or directory
```
